### PR TITLE
add parameter getClient to getAccessToken()

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ $fb = App::make('laravel-facebook-sdk');
 
 try
 {
-    $token = $fb->getRedirectLoginHelper()->getAccessToken('http://my-custom-callback/url');
+    $fbClient = Facebook::getClient();
+    $token = $fb->getRedirectLoginHelper()->getAccessToken($fbClient, 'http://my-custom-callback/url');
 }
 catch (\Facebook\Exceptions\FacebookSDKException $e)
 {


### PR DESCRIPTION
I am very desolated for my poor English level,
will have one small error on your documentation you must  add a parameter to the function "getAccessToken" for to have the token if not it will trigger an error calling this method
here is the the parameter "Facebook::getClient()"
