### PR TITLE
Bugfix

### DIFF
--- a/src/LaravelFacebookSdk/SyncableGraphNodeTrait.php
+++ b/src/LaravelFacebookSdk/SyncableGraphNodeTrait.php
@@ -25,7 +25,7 @@ trait SyncableGraphNodeTrait
     {
         // @todo this will be GraphNode soon
         if ($data instanceof GraphObject) {
-            $data = $data->asArray();
+            $data = array_dot($data->asArray());
         }
 
         if (! isset($data['id'])) {


### PR DESCRIPTION
This is a bugfix for https://github.com/SammyK/LaravelFacebookSdk/issues/62
It will allow you to add something like:
    protected static $graph_node_field_aliases = [
        'location.name' => 'fb_location',
        'location.id' => 'fb_location_id',
];