### PR TITLE
fixed #74, adding support for Laravel 5.1

### DIFF
--- a/src/LaravelFacebookSdk/SyncableGraphNodeTrait.php
+++ b/src/LaravelFacebookSdk/SyncableGraphNodeTrait.php
@@ -53,7 +53,7 @@ trait SyncableGraphNodeTrait
      */
     public static function firstOrNewGraphNode(array $attributes)
     {
-        if (is_null($facebook_object = static::firstByAttributes($attributes))) {
+        if (is_null($facebook_object = static::where($attributes)->first())) {
             $facebook_object = new static();
         }
 


### PR DESCRIPTION
I'm not able to run the tests because of the following error, but this should fix the error with Laravel 5.1. It's also the way the firstByAttribute is suggested to be replaced: https://github.com/laravel/framework/pull/7303

    PHPUnit 4.7.5 by Sebastian Bergmann and contributors.

    Runtime:	PHP 5.5.20
    Configuration:	/Users/fabianpimminger/Development/forks/LaravelFacebookSdk/phpunit.xml.dist

    .......PHP Fatal error:  Call to a member function connection() on a non-object in /Users/fabianpimminger/Development/forks/LaravelFacebookSdk/vendor/illuminate/database/Eloquent/Model.php on line 3138

Any idea what's the problem here?