### PR TITLE
Use Config Repo Contract.

### DIFF
--- a/src/LaravelFacebookSdk/LaravelFacebookSdk.php
+++ b/src/LaravelFacebookSdk/LaravelFacebookSdk.php
@@ -1,6 +1,6 @@
 <?php namespace SammyK\LaravelFacebookSdk;
 
-use Illuminate\Config\Repository as Config;
+use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Routing\UrlGenerator as Url;
 use Facebook\Facebook;
 


### PR DESCRIPTION
It causes a conflict if the config repo is extended, starts throwing error. For example:

```
Argument 1 passed to SammyK\LaravelFacebookSdk\LaravelFacebookSdk::__construct() must be an instance of Illuminate\Config\Repository, instance of Orchestra\Config\Repository given, called in /../vendor/sammyk/laravel-facebook-sdk/src/LaravelFacebookSdk/LaravelFacebookSdkServiceProvider.php on line 45 and defined
```

This PR fixes this issue.