### PR TITLE
SyncableGraphNodeTrait createOrUpdateGraphNode without saving model

### DIFF
--- a/src/LaravelFacebookSdk/SyncableGraphNodeTrait.php
+++ b/src/LaravelFacebookSdk/SyncableGraphNodeTrait.php
@@ -61,6 +61,37 @@ trait SyncableGraphNodeTrait
     }
 
     /**
+     * Inserts or updates the Graph node to the local database
+     *
+     * @param array|GraphObject|GraphNode $data
+     *
+     * @return Model
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function newOrUpdateGraphNode($data)
+    {
+        // @todo this will be GraphNode soon
+        if ($data instanceof GraphObject || $data instanceof GraphNode) {
+            $data = array_dot($data->asArray());
+        }
+
+        $data = static::convertGraphNodeDateTimesToStrings($data);
+
+        if (! isset($data['id'])) {
+            throw new \InvalidArgumentException('Graph node id is missing');
+        }
+
+        $attributes = [static::getGraphNodeKeyName() => $data['id']];
+
+        $graph_node = static::firstOrNewGraphNode($attributes);
+
+        static::mapGraphNodeFieldNamesToDatabaseColumnNames($graph_node, $data);
+
+        return $graph_node;
+    }
+
+    /**
      * Like static::firstOrNew() but without mass assignment
      *
      * @param array $attributes


### PR DESCRIPTION
In `SyncableGraphNodeTrait` a method is added : `public static function newOrUpdateGraphNode($data)` based on method `createOrUpdateGraphNode($data)` but without saving the model before returning it.

if two objects have a relationship, this method `newOrUpdateGraphNode` allows creating object in batch for example _facebook pages_ and linked them once with a user object

```
$requestLikes = $fb->get('/me/likes?fields=id,name,picture');
$likesEdge = $requestLikes->getGraphEdge();
do {
  $jsonLikesArray = $likesEdge->asArray();
  $likes = array();
    foreach($jsonLikesArray as $jsonLike) {
      $like = \App\Like::createOrUpdateGraphNode($jsonLike);
      array_push($likes, $like);
  }
  $user->likes()->saveMany($likes);
  $likes = null;
}
while ( $likesEdge = $fb->next($likesEdge) );
```