### PR TITLE
SyncableGraphNodeTrait new method for flexibility

### DIFF
--- a/src/LaravelFacebookSdk/SyncableGraphNodeTrait.php
+++ b/src/LaravelFacebookSdk/SyncableGraphNodeTrait.php
@@ -61,6 +61,37 @@ trait SyncableGraphNodeTrait
     }
 
     /**
+     * Inserts or updates the Graph node to the local database
+     *
+     * @param array|GraphObject|GraphNode $data
+     *
+     * @return Model
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function newOrUpdateGraphNode($data)
+    {
+        // @todo this will be GraphNode soon
+        if ($data instanceof GraphObject || $data instanceof GraphNode) {
+            $data = array_dot($data->asArray());
+        }
+
+        $data = static::convertGraphNodeDateTimesToStrings($data);
+
+        if (! isset($data['id'])) {
+            throw new \InvalidArgumentException('Graph node id is missing');
+        }
+
+        $attributes = [static::getGraphNodeKeyName() => $data['id']];
+
+        $graph_node = static::firstOrNewGraphNode($attributes);
+
+        static::mapGraphNodeFieldNamesToDatabaseColumnNames($graph_node, $data);
+
+        return $graph_node;
+    }
+
+    /**
      * Like static::firstOrNew() but without mass assignment
      *
      * @param array $attributes

--- a/src/LaravelFacebookSdk/SyncableGraphNodeTrait.php
+++ b/src/LaravelFacebookSdk/SyncableGraphNodeTrait.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Eloquent\Model;
 use Facebook\GraphNodes\GraphObject;
 use Facebook\GraphNodes\GraphNode;
+use Facebook\GraphNodes\GraphEdge;
 
 trait SyncableGraphNodeTrait
 {
@@ -72,7 +73,7 @@ trait SyncableGraphNodeTrait
     public static function newOrUpdateGraphNode($data)
     {
         // @todo this will be GraphNode soon
-        if ($data instanceof GraphObject || $data instanceof GraphNode) {
+        if ($data instanceof GraphObject || $data instanceof GraphNode || $data instanceof GraphEdge) {
             $data = array_dot($data->asArray());
         }
 
@@ -81,6 +82,7 @@ trait SyncableGraphNodeTrait
         if (! isset($data['id'])) {
             throw new \InvalidArgumentException('Graph node id is missing');
         }
+        var_dump($data);
 
         $attributes = [static::getGraphNodeKeyName() => $data['id']];
 
@@ -121,7 +123,6 @@ trait SyncableGraphNodeTrait
             && isset(static::$graph_node_field_aliases[$field])) {
             return static::$graph_node_field_aliases[$field];
         }
-
         return $field;
     }
 


### PR DESCRIPTION
In SyncableGraphNodeTrait a method is added : public static function newOrUpdateGraphNode($data) based on method createOrUpdateGraphNode($data) but without saving the model before returning it.

if two objects have a relationship, this method newOrUpdateGraphNode allows creating object in batch for example facebook pages and linked them once with a user object

$requestLikes = $fb->get('/me/likes?fields=id,name,picture');
$likesEdge = $requestLikes->getGraphEdge();
do {
  $jsonLikesArray = $likesEdge->asArray();
  $likes = array();
    foreach($jsonLikesArray as $jsonLike) {
      $like = \App\Like::createOrUpdateGraphNode($jsonLike);
      array_push($likes, $like);
  }
  $user->likes()->saveMany($likes);
  $likes = null;
}
while ( $likesEdge = $fb->next($likesEdge) );

without this an error is thrown :

SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`dbname`.`likes`, CONSTRAINT `likes_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)) (SQL: insert into `likes` (`facebook_id`, `name`, `updated_at`, `created_at`) values (#val1#, #val2#, #val3#, #val4#))",
because we try to save a like object without having set it the user_id …

I thought it's a little more flexible for a common use
