### PR TITLE
Change installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,7 @@ But if you need any of the following features, you'll want to tie in the Faceboo
 
 Add the Laravel Facebook SDK package to your `composer.json` file.
 
-```json
-{
-    "require": {
-        "sammyk/laravel-facebook-sdk": "^3.0"
-    }
-}
-```
+    composer require sammyk/laravel-facebook-sdk
 
 
 ### Service Provider


### PR DESCRIPTION
I suggest to change installation guide. It is simpler and faster to use Composer command line to install dependencies than adding them to `composer.json` manually.
