### PR TITLE
Add static method to translate graph node to db columns

### DIFF
--- a/src/LaravelFacebookSdk/SyncableGraphNodeTrait.php
+++ b/src/LaravelFacebookSdk/SyncableGraphNodeTrait.php
@@ -120,6 +120,25 @@ trait SyncableGraphNodeTrait
     }
 
     /**
+     * Translates the Graph Node's keys into database columns
+     * 
+     * @param $fields
+     *
+     * @return array
+     */
+    public static function convertGraphFieldsToColumns($fields) {
+        if ($fields instanceof GraphObject || $fields instanceof GraphNode) {
+            $fields = array_dot($fields->asArray());
+        }
+        $columns = [];
+        foreach($fields as $field => $value) {
+            $columns[static::fieldToColumnName($field)] = $value;
+        }
+
+        return $columns;
+    }
+
+    /**
      * Convert instances of \DateTime to string
      *
      * @param array $data


### PR DESCRIPTION
I've used this so I can translate my graph edge into an array, then perform a single insert instead of using `createOrUpdateGraphNode` because that will perform a separate insert for every loop.