### PR TITLE
officially supports laravel 5.5, versioning fixed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "illuminate/auth": "~5.0|~5.1|~5.2|~5.3",
-        "illuminate/config": "~5.0|~5.1|~5.2|~5.3",
-        "illuminate/database": "~5.0|~5.1|~5.2|~5.3",
-        "illuminate/routing": "~5.0|~5.1|~5.2|~5.3",
-        "illuminate/session": "~5.0|~5.1|~5.2|~5.3",
-        "illuminate/support": "~5.0|~5.1|~5.2|~5.3",
+        "illuminate/auth": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
+        "illuminate/config": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
+        "illuminate/database": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
+        "illuminate/routing": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
+        "illuminate/session": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
+        "illuminate/support": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
         "facebook/graph-sdk": "^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hey Sammy,

~5.0 | ~5.1 | 5.2 ...
makes no sense in the laravel world cause ~5.0 means 5.0 to 5.9999... :stuck_out_tongue: 
hence fixed the versioning to make it clear that it supports 5.0 to 5.5 only 

Cheers