### PR TITLE
Fix Solved merge config error( Error: Uncaught ReflectionException: Class config does not exist in)

### DIFF
--- a/src/LaravelFacebookSdk/LaravelFacebookSdkServiceProvider.php
+++ b/src/LaravelFacebookSdk/LaravelFacebookSdkServiceProvider.php
@@ -30,7 +30,7 @@ class LaravelFacebookSdkServiceProvider extends ServiceProvider
 
         if ($this->isLumen()) {
             $this->app->configure('laravel-facebook-sdk');
-        }else{
+        } else {
             $this->publishes([$configPath => config_path('laravel-facebook-sdk.php')]);
         }
 

--- a/src/LaravelFacebookSdk/LaravelFacebookSdkServiceProvider.php
+++ b/src/LaravelFacebookSdk/LaravelFacebookSdkServiceProvider.php
@@ -26,9 +26,15 @@ class LaravelFacebookSdkServiceProvider extends ServiceProvider
             return;
         }
 
-        $this->publishes([
-            __DIR__.'/../config/laravel-facebook-sdk.php' => \config_path('laravel-facebook-sdk.php'),
-        ], 'config');
+        $configPath = realpath(__DIR__ . '/../config/laravel-facebook-sdk.php');
+
+        if ($this->isLumen()) {
+            $this->app->configure('laravel-facebook-sdk');
+        }else{
+            $this->publishes([$configPath => config_path('laravel-facebook-sdk.php')]);
+        }
+
+        $this->mergeConfigFrom($configPath, 'laravel-facebook-sdk');
     }
 
     /**
@@ -38,11 +44,6 @@ class LaravelFacebookSdkServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        if ($this->isLumen()) {
-            $this->app->configure('laravel-facebook-sdk');
-        }
-        $this->mergeConfigFrom(__DIR__.'/../config/laravel-facebook-sdk.php', 'laravel-facebook-sdk');
-
         // Main Service
         $this->app->bind('SammyK\LaravelFacebookSdk\LaravelFacebookSdk', function ($app) {
             $config = $app['config']->get('laravel-facebook-sdk.facebook_config');


### PR DESCRIPTION
- Laravel : v5.5.1
- SDK : 3.5.0

When using version 3.5, I found an error in the source that `mergeConfigForm`.
If the source code is placed in the `function register(){}` the following error occurs.

````
Uncaught ReflectionException: Class config does not exist in .. blah blah
````

So I moved to the `function boot(){}` and modified the slightly fixed source.
And it works well.

almost same code
